### PR TITLE
Removed pr-labeler on push events

### DIFF
--- a/workflow-templates/pr-labeler.yml
+++ b/workflow-templates/pr-labeler.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-  push:
 
 
 jobs:


### PR DESCRIPTION
The drawback by using this is that the action is runned twice when
opening a PR. Instead of this the pr-labeler is removed from the
required action before merging.