### PR TITLE
Added norn-* to PR labeler

### DIFF
--- a/.github/release-drafter-labeler-config.yml
+++ b/.github/release-drafter-labeler-config.yml
@@ -18,4 +18,6 @@ autolabeler:
   - label: 'skip-release-note'
     branch:
       - '/update_README\.md/'
+      - '/norn-.+/'
+      - '/skiprn-.+/'
 template: '# Labeler'


### PR DESCRIPTION
Now PR with head branch matching norn-* and/or skiprn-* will be labeled
as skip-release-note.