### PR TITLE
Renamed the workflow templates

### DIFF
--- a/scripts/milestone-workflow-setup.sh
+++ b/scripts/milestone-workflow-setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+repository=(
+    "test-milestone-workflow"
+    # "service-wms-bod"
+    # "wms-bgdi"
+    # "wms-mapfile_include"
+    # "mf-chsdi3"
+    # "service-sphinxsearch"
+)
+
+branch_name=norn-update-workflow
+
+echo "Check if all repos are clean and if we can create new branch from them..."
+for repo in "${repository[@]}"
+do
+    echo "Entering repositories/${repo}"
+    pushd ~/repositories/"${repo}" || exit
+    git checkout master || exit
+    git pull || exit
+    git status --porcelain && echo "local changes on master, exiting..."; exit
+    git checkout -b ${branch_name} || exit
+    echo "--------------------------------------------------------------------"
+done
+
+echo "Done"
+echo "------------------------------------------------------------------------"
+echo -n "All repos are clean do you want to continue [Y/n] ? "
+read -r answer
+case "$answer" in
+    "Y" | "y" | "") echo "Continue" ;;
+    *) echo "Stop"; exit 0 ;;
+esac
+
+read -r -d '' MSG << EOM
+Added new Milestone Workflows
+EOM
+
+for repo in "${repository[@]}"
+do
+    echo "Entering repositories/${repo}"
+    pushd ~/repositories/"${repo}" || exit
+    git checkout ${branch_name} || exit
+    rm -f .github/workflows/*
+    cp ~/repositories/geoadmin.github/workflow-templates/milestone-version.yml .github/workflows/ || exit
+    cp ~/repositories/geoadmin.github/workflow-templates/pr-auto-milestone.yml .github/workflows/ || exit
+    cp ~/repositories/geoadmin.github/workflow-templates/create-milestone.yml .github/workflows/ || exit
+    git add --all .github/workflows/ || exit
+    git commit -m "$MSG" || exit
+    git push -f origin HEAD || exit
+    popd || exit
+    echo "--------------------------------------------------------------------"
+done

--- a/scripts/semver-workflow-setup.sh
+++ b/scripts/semver-workflow-setup.sh
@@ -25,6 +25,7 @@ do
     pushd ~/repositories/"${repo}" || exit
     git checkout develop || exit
     git pull || exit
+    git status --porcelain && echo "local changes on develop, exiting..."; exit
     git checkout -b ${branch_name} || exit
     echo "--------------------------------------------------------------------"
 done
@@ -39,12 +40,22 @@ case "$answer" in
 esac
 
 read -r -d '' MSG << EOM
-Consolidate PR workflows
+Renamed the workflow templates
 
-Now the PR set Title and PR labeler are inside the same workflow. This speed up
-a little bit the execution but moreover it simplify the maintenance of the workflows.
+The main workflow file parameter `name` is used in the github PR check
+section as prefix to display every actions. In order to keep this display
+a bit cleaner and short we use a shorter name.
 
-Also added proper job names that are displayed inside the PR.
+e.g changed such display:
+
+`PR New SemVer Release Auto Title / pr-edit / Set PR title (pull_request)`
+`PR New SemVer Release Auto Title / pr-edit / Set PR label
+(pull_request)`
+
+to
+
+`on-pr / pr-edit / Set PR title (pull_request)`
+`on-pr / pr-edit / Set PR label (pull_request)`
 EOM
 
 for repo in "${repository[@]}"
@@ -52,7 +63,6 @@ do
     echo "Entering repositories/${repo}"
     pushd ~/repositories/"${repo}" || exit
     git checkout ${branch_name} || exit
-    # rm -f .github/workflows/*
     cp ~/repositories/geoadmin.github/workflow-templates/semver.yml .github/workflows/ || exit
     cp ~/repositories/geoadmin.github/workflow-templates/pr-auto-semver.yml .github/workflows/ || exit
     git add --all .github/workflows/ || exit

--- a/scripts/semver-workflow-setup.sh
+++ b/scripts/semver-workflow-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 repository=(
+    "test-semver-workflow"
     "service-qrcode"
     "service-stac"
     "service-icons"
@@ -15,6 +16,8 @@ repository=(
     "config-vt-gl-styles"
 )
 
+branch_name=norn-update-workflow
+
 echo "Check if all repos are clean and if we can create new branch from them..."
 for repo in "${repository[@]}"
 do
@@ -22,7 +25,18 @@ do
     pushd ~/repositories/"${repo}" || exit
     git checkout develop || exit
     git pull || exit
+    git checkout -b ${branch_name} || exit
+    echo "--------------------------------------------------------------------"
 done
+
+echo "Done"
+echo "------------------------------------------------------------------------"
+echo -n "All repos are clean do you want to continue [Y/n] ? "
+read -r answer
+case "$answer" in
+    "Y" | "y" | "") echo "Continue" ;;
+    *) echo "Stop"; exit 0 ;;
+esac
 
 read -r -d '' MSG << EOM
 Consolidate PR workflows
@@ -37,15 +51,13 @@ for repo in "${repository[@]}"
 do
     echo "Entering repositories/${repo}"
     pushd ~/repositories/"${repo}" || exit
-    git checkout -f develop || exit
-    git pull || exit
-    git checkout -B norn-update-workflow || exit
-    rm pr-semver-release-title.yml
-    rm .github/workflows/*
+    git checkout ${branch_name} || exit
+    # rm -f .github/workflows/*
     cp ~/repositories/geoadmin.github/workflow-templates/semver.yml .github/workflows/ || exit
     cp ~/repositories/geoadmin.github/workflow-templates/pr-auto-semver.yml .github/workflows/ || exit
-    git add .github/workflows/*
-    git commit -m "$MSG"
-    git push origin HEAD
+    git add --all .github/workflows/ || exit
+    git commit -m "$MSG" || exit
+    git push -f origin HEAD || exit
     popd || exit
+    echo "--------------------------------------------------------------------"
 done

--- a/workflow-templates/create-milestone.yml
+++ b/workflow-templates/create-milestone.yml
@@ -1,4 +1,4 @@
-name: Create Milestone if needed
+name: on-create
 
 on:
   create:

--- a/workflow-templates/milestone-version.yml
+++ b/workflow-templates/milestone-version.yml
@@ -1,4 +1,4 @@
-name: Bump Milestone Version
+name: on-pr-close
 
 on:
   pull_request:

--- a/workflow-templates/pr-auto-milestone.yml
+++ b/workflow-templates/pr-auto-milestone.yml
@@ -1,4 +1,4 @@
-name: PR Milestone Auto Edit
+name: on-pr
 
 on:
   pull_request:

--- a/workflow-templates/pr-auto-semver.yml
+++ b/workflow-templates/pr-auto-semver.yml
@@ -1,4 +1,4 @@
-name: PR New SemVer Release Auto Title
+name: on-pr
 
 on:
   pull_request:

--- a/workflow-templates/semver.yml
+++ b/workflow-templates/semver.yml
@@ -1,4 +1,4 @@
-name: Bump SemVer Version
+name: on-push
 
 on:
   push:


### PR DESCRIPTION
The main workflow file parameter name is used in the github PR check
section as prefix to display every actions. In order to keep this display
a bit cleaner and short we use a shorter name.

e.g changed such display:

`PR New SemVer Release Auto Title / pr-edit / Set PR title (pull_request)`
`PR New SemVer Release Auto Title / pr-edit / Set PR label (pull_request)`

to

`on-pr / pr-edit / Set PR title (pull_request)`
`on-pr / pr-edit / Set PR label (pull_request)`

Also updated the semver-workflow-setup.sh script to apply these changes
to the repo and added the milestone-workflow-setup.sh script.