### PR TITLE
Changed hotfix release notes

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -8,6 +8,9 @@ categories:
       - 'fix'
       - 'bugfix'
       - 'bug'
+  - title: 'Hot Fixes'
+    labels:
+      - 'hotfix'
   - title: 'Data Integration'
     label:
       - 'data'

--- a/.github/release-drafter-labeler-config.yml
+++ b/.github/release-drafter-labeler-config.yml
@@ -11,6 +11,10 @@ autolabeler:
       - '/bug[-_].+/'
       - '/bugfix[-_].+/'
       - '/fix[-_].+/'
+  - label: 'hotfix'
+    branch:
+      - '/hotfix[-_].+'
+      - '/hot[-_].+'
   - label: 'feature'
     branch:
       - '/feature[-_].+/'

--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -71,14 +71,6 @@ jobs:
           title: "New Release ${{ steps.get_tag.outputs.new_tag }}"
           body: ${{ steps.pr_infos.outputs.body }}
 
-      - name: Set `Hotfix` PR title if needed
-        if: ${{ steps.get_tag.outputs.new_tag != '' && !startsWith(github.head_ref, 'develop-') }}
-        uses: juztcode/pr-updater@1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "${{ steps.get_tag.outputs.new_tag }} - ${{ steps.pr_infos.outputs.title }}"
-          body: ${{ steps.pr_infos.outputs.body }}
-
   pr-labeler:
     name: Set PR label
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -110,7 +110,7 @@ jobs:
         uses: juztcode/pr-updater@1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: "${{ steps.get_tag.outputs.new_tag }} - ${{ steps.bump_type.outputs.pr_title }} - #${{ steps.bump_type.outputs.bump }}"
+          title: "${{ steps.bump_type.outputs.pr_title }} - #${{ steps.bump_type.outputs.bump }}"
           body: ${{ steps.pr_infos.outputs.body }}
 
   pr-labeler:


### PR DESCRIPTION
The hotfix PR title where prefixed with the version. Because the hotfix
PR title are then added to the Release Notes, this makes the version in
RN redundant and not very nice. Therefore now we don't prefix anymore
the hotfix PR with the version and we also labeled them as hotfix to
specify it in RN.