### PR TITLE
Fixed milestone version to match the docu

### DIFF
--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -2,7 +2,7 @@ name: Milestone Release Reusable Workflow
 
 # Tag and create a Release for milestone workflow. The repository is tagged
 # based on the milestone title which should be in the form YYYY-MM-DD. The
-# tag is then <MILESTONE>_RC<X> where X is a milestone build number starting from 1.
+# tag is then <MILESTONE>-rc<X> where X is a milestone build number starting from 1.
 # The github release is then generated with release notes. The release notes are
 # generated from the PR titles.
 
@@ -42,7 +42,7 @@ jobs:
       uses: geoadmin/action-milestone-tag@v1.2.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: '${MILESTONE}_rc${TAG_NUMBER}'
+        custom_tag: '${MILESTONE}-rc${TAG_NUMBER}'
         milestone_pattern: '\d{4}-\d{2}-\d{2}'
 
     # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/scripts/milestone-workflow-setup.sh
+++ b/scripts/milestone-workflow-setup.sh
@@ -1,29 +1,28 @@
 #!/bin/bash
 
 repository=(
-    "test-milestone-workflow"
-    # "service-wms-bod"
-    # "wms-bgdi"
-    # "wms-mapfile_include"
-    # "mf-chsdi3"
-    # "service-sphinxsearch"
+    #"test-milestone-workflow"
+    "service-wms-bod"
+    "wms-bgdi"
+    "wms-mapfile_include"
+    "mf-chsdi3"
+    "service-sphinxsearch"
 )
 
 branch_name=norn-update-workflow
 
+
+tmp_dir=$(mktemp -d -t workflows-setup-XXXX)
+
 echo "Check if all repos are clean and if we can create new branch from them..."
 for repo in "${repository[@]}"
 do
-    echo "Entering repositories/${repo}"
-    pushd ~/repositories/"${repo}" || exit
+    echo "Cloning and entering ${tmp_dir}/${repo}"
+    pushd "${tmp_dir}" || exit
+    git clone "git@github.com:geoadmin/${repo}.git" || exit
+    pushd "${repo}" || exit
     git checkout master || exit
     git pull || exit
-    local_changes=$(git status --porcelain)
-    if [ -n "${local_changes}" ]; then
-        echo "${local_changes}"
-        echo "local changes on develop, exiting..."
-        exit
-    fi
     git checkout -b ${branch_name} || exit
     echo "--------------------------------------------------------------------"
 done
@@ -43,10 +42,11 @@ EOM
 
 for repo in "${repository[@]}"
 do
-    echo "Entering repositories/${repo}"
-    pushd ~/repositories/"${repo}" || exit
+    echo "Entering ${tmp_dir}/${repo}"
+    pushd "${tmp_dir}/${repo}" || exit
     git checkout ${branch_name} || exit
     rm -f .github/workflows/*
+    mkdir -p .github/workflows/
     cp ~/repositories/geoadmin.github/workflow-templates/milestone-version.yml .github/workflows/ || exit
     cp ~/repositories/geoadmin.github/workflow-templates/pr-auto-milestone.yml .github/workflows/ || exit
     cp ~/repositories/geoadmin.github/workflow-templates/create-milestone.yml .github/workflows/ || exit
@@ -56,3 +56,5 @@ do
     popd || exit
     echo "--------------------------------------------------------------------"
 done
+
+rm -rf "${tmp_dir}"


### PR DESCRIPTION
In the docu the milestone tag pattern is `YYYY-MM-DD-rcX` but in the workflow was `YYYY-MM-DD_rcX`. Because the tag 2021-12-15-rc1 has already been added manually to all milestone repo, we need to change this in the workflow in order to make it work.