### PR TITLE
Auto close milestone upons develop-* merge and allow reopen milestone

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -36,8 +36,10 @@ jobs:
 
       - name: Create Milestone if it not exists
         if: ${{ steps.get-milestone.outputs.milestone }}
-        uses: "sv-tools/create-milestone-action@v1.1.0"
+        uses: "julb/action-manage-milestone@v1"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           title: ${{ steps.get-milestone.outputs.milestone }}
-          due_on: ${{ steps.get-milestone.outputs.milestone}}T17:00:00Z
+          state: open
+          due_on: ${{ steps.get-milestone.outputs.milestone}}

--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -58,3 +58,22 @@ jobs:
         name: ${{ steps.tagging.outputs.new_tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Close the milestone if needed
+    - name: Get milestone name from tag
+      if: ${{ startsWith(github.head_ref, 'develop-') }}
+      id: get-milestone
+      shell: bash
+      run: |
+        tag=${{ steps.tagging.outputs.new_tag }}
+        milestone=${tag%%-rc*}
+        echo "::set-output name=milestone::${milestone}"
+        echo "::notice::Milestone is ${milestone}"
+    - name: Close the milestone if needed
+      if: ${{ startsWith(github.head_ref, 'develop-') }}
+      uses: "julb/action-manage-milestone@v1"
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        title: ${{ steps.get-milestone.outputs.milestone }}
+        state: closed


### PR DESCRIPTION
The previous create milestone did not work if the milestone already
existed but was closed. In this case the milestone stayed closed.

Now it alow reopen and it also automatically close the milestone when a
new milestone release has been created.