### PR TITLE
Fixed semver release unsafe repository error

### DIFF
--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
           ref: master
 
-      # This step is needed in order for the anothrNick/github-tag-action@1.33.0 action to work properly
+      # This step is needed in order for the anothrNick/github-tag-action@1.39.0 action to work properly
       - name: Do the merge but don't push it
         run: |
           cd ${GITHUB_WORKSPACE}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Bump version (without tagging)
         id: get_tag
-        uses: anothrNick/github-tag-action@1.33.0
+        uses: anothrNick/github-tag-action@1.39.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -34,7 +34,7 @@ jobs:
     # https://github.com/geoadmin/doc-guidelines/blob/master/GIT_FLOW.md#versioning
     - name: Bump version and push tag
       id: tagging
-      uses: anothrNick/github-tag-action@1.33.0
+      uses: anothrNick/github-tag-action@1.39.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true


### PR DESCRIPTION
Fixed the following error:

```bash
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```