### PR TITLE
Fixed a bug in the `Add PR to Milestone` when no milestone exist

### DIFF
--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -33,11 +33,12 @@ jobs:
       milestone: ${{ steps.action_milestone.outputs.milestone }}
     steps:
       - id: action_milestone
-        uses: iyu/actions-milestone@v1.1.0
+        uses: iyu/actions-milestone@v1.2.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/pr-2-milestone-config.yml@master
           configuration-repo: geoadmin/.github
+          silent: false
 
   check-open-pr:
     needs: add-milestone
@@ -47,7 +48,7 @@ jobs:
     steps:
       - name: Check if there is any open PR(s) on HEAD branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           api_call="https://api.github.com/repos/${{ github.repository }}/pulls?state=open&base=${{ github.head_ref }}"
@@ -59,7 +60,7 @@ jobs:
           else
             echo "::notice::No open PRs on branch ${{ github.head_ref }}"
           fi
- 
+
   set-title:
     needs: add-milestone
     name: Set PR title


### PR DESCRIPTION
In the `Add PR to Milestone` action, when the milestone did not exists (e.g.
has been already closed or deleted) the action failed silently. In this
case the version in the PR title might have been wrongly set. This happened
at least once.

Now this action is failing in case the milestone doesn't exists yet and
other actions are not performed.