### PR TITLE
Auto milestone branch protection and deletion

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -14,7 +14,7 @@ name: Create Milestone from branch name Reusable Workflow
 #    uses: geoadmin/.github/.github/workflows/create-milestone.yml@master
 #    secrets: inherit
 #    with:
-#      ci_status_check_name: 'AWS CodeBuild eu-central-1 (rCODEBUILD_PROJECT_NAME)'
+#      ci_status_check_name: 'AWS CodeBuild eu-central-1 (CODEBUILD_PROJECT_NAME)'
 
 on:
   workflow_call:
@@ -24,7 +24,7 @@ on:
         type: string
         description: 'CI status check name that must pass for merging. Set to empty string to disable check.'
     secrets:
-      MY_SECRET:
+      REPO_ACCESS_TOKEN:
         required: true
 
 jobs:
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Create Milestone Branch Protection
         env:
-          GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
           HUB_VERBOSE: 0
         run: |
           required_status_checks=null
@@ -79,7 +79,7 @@ jobs:
             --input "-" <<STDIN
           {
             "required_status_checks": ${required_status_checks},
-            "enforce_admins": false,
+            "enforce_admins": true,
             "restrictions": null,
             "required_pull_request_reviews": {"required_approving_review_count": 1}
           }
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Set default branch to milestone
         env:
-          GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
         run: |
           # Get the next milestone branch
           next_milestone_branch=$(gh api \

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -1,7 +1,8 @@
 name: Create Milestone from branch name Reusable Workflow
 
 # If the branch name match the milestone branch pattern develop-YYYY-MM-DD, then the milestone
-# name YYYY-MM-DD is created if it not already exists.
+# name YYYY-MM-DD is created if it not already exists. It also create a milestone branch protection
+# and set the default branch to the milestone branch.
 #
 # Usage example
 #--------------
@@ -11,14 +12,28 @@ name: Create Milestone from branch name Reusable Workflow
 #jobs:
 #  create-milestone:
 #    uses: geoadmin/.github/.github/workflows/create-milestone.yml@master
+#    secrets: inherit
+#    with:
+#      ci_status_check_name: 'AWS CodeBuild eu-central-1 (rCODEBUILD_PROJECT_NAME)'
 
 on:
   workflow_call:
+    inputs:
+      ci_status_check_name:
+        default: ''
+        type: string
+        description: 'CI status check name that must pass for merging. Set to empty string to disable check.'
+    secrets:
+      MY_SECRET:
+        required: true
 
 jobs:
-  create-milestone:
-    name: Create Milestone
+  get-milestone:
+    name: Check if it's a milestone branch
     runs-on: ubuntu-latest
+    outputs:
+      milestone: ${{ steps.get-milestone.outputs.milestone }}
+      branch: ${{ steps.get-milestone.outputs.branch }}
     steps:
       - name: Get Milestone from branch name
         id: get-milestone
@@ -31,15 +46,69 @@ jobs:
               echo "::notice::${GITHUB_REF} is a milestone branch"
               milestone=${GITHUB_REF#refs/heads/${branch_prefix}}
               echo "::set-output name=milestone::${milestone}"
+              echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
               echo "::notice::Milestone is ${milestone}"
             fi
 
+  create-milestone-branch-protection:
+    name: Create Milestone Branch Protection
+    needs: get-milestone
+    if: "${{ needs.get-milestone.outputs.milestone }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Milestone Branch Protection
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+          HUB_VERBOSE: 0
+        run: |
+          required_status_checks=null
+          if [[ -n "${{ inputs.ci_status_check_name }}" ]];
+          then
+            required_status_checks=$(cat <<-END
+              {
+                "strict": true,
+                "contexts": [
+                  "${{ inputs.ci_status_check_name }}"
+                ]
+              }
+          END)
+          fi
+
+          hub api -i -X PUT /repos/${{ github.repository }}/branches/${{ needs.get-milestone.outputs.branch }}/protection \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            --input "-" <<STDIN
+          {
+            "required_status_checks": ${required_status_checks},
+            "enforce_admins": false,
+            "restrictions": null,
+            "required_pull_request_reviews": {"required_approving_review_count": 1}
+          }
+          STDIN
+
+  set-default-branch:
+    name: Set default branch to milestone branch
+    needs: get-milestone
+    if: "${{ needs.get-milestone.outputs.milestone }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set default branch to milestone
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+        run: |
+          gh repo edit ${{ github.repository }} --default-branch ${{ needs.get-milestone.outputs.branch }}
+
+  create-milestone:
+    name: Create Milestone
+    needs: get-milestone
+    if: "${{ needs.get-milestone.outputs.milestone }}"
+    runs-on: ubuntu-latest
+    steps:
       - name: Create Milestone if it not exists
-        if: ${{ steps.get-milestone.outputs.milestone }}
         uses: "julb/action-manage-milestone@v1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: ${{ steps.get-milestone.outputs.milestone }}
+          title: "${{ needs.get-milestone.outputs.milestone }}"
           state: open
-          due_on: ${{ steps.get-milestone.outputs.milestone}}
+          due_on: "${{ needs.get-milestone.outputs.milestone }}"
+

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -39,7 +39,7 @@ jobs:
         id: get-milestone
         shell: bash
         run: |
-            echo "::notice::Branch ${GITHUB_REF} created"
+            echo "::notice::Branch \"${GITHUB_REF}\" created"
             branch_prefix=develop-
             pattern=^refs/heads/${branch_prefix}[0-9]{4}-[0-9]{2}-[0-9]{2}$
             if [[ "${GITHUB_REF}" =~ $pattern ]]; then
@@ -84,6 +84,7 @@ jobs:
             "required_pull_request_reviews": {"required_approving_review_count": 1}
           }
           STDIN
+          echo "::notice::Milestone Branch Protection \"${{ needs.get-milestone.outputs.branch }}\" created"
 
   set-default-branch:
     name: Set default branch to milestone branch
@@ -95,7 +96,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
         run: |
-          gh repo edit ${{ github.repository }} --default-branch ${{ needs.get-milestone.outputs.branch }}
+          # Get the next milestone branch
+          next_milestone_branch=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/branches | \
+            jq '. | map(select(.name | test("develop-\\d{4}-\\d{2}-\\d{2}"))) | sort_by(.name) | .[0].name ' -r)
+          if [[ "${next_milestone_branch}" != "null" ]];
+          then
+            echo "::notice::Set default branch to \"${next_milestone_branch}\""
+            gh repo edit ${{ github.repository }} --default-branch ${next_milestone_branch}
+          else
+            echo "::warning::No milestone branch found !"
+          fi
 
   create-milestone:
     name: Create Milestone

--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -24,7 +24,7 @@ name: Milestone Release Reusable Workflow
 on:
   workflow_call:
     secrets:
-      MY_SECRET:
+      REPO_ACCESS_TOKEN:
         required: true
 
 jobs:
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Delete Milestone Branch Protection
       env:
-        GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+        GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
         HUB_VERBOSE: 0
       run: |
         set +e
@@ -60,7 +60,7 @@ jobs:
         fi
     - name: Delete Milestone Branch
       env:
-        GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+        GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
         HUB_VERBOSE: 0
       run: |
         set +e
@@ -94,7 +94,7 @@ jobs:
     steps:
     - name: Set default branch back to master or to next milestone branch
       env:
-        GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+        GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
       run: |
         next_milestone_branch=$(gh api \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -44,7 +44,7 @@ jobs:
         then
           set -e
           # 200 OK
-          echo "::notice::Milestone Branch Protection deleted"
+          echo "::notice::Milestone Branch Protection \"${{ github.head_ref }}\" deleted"
         else
           set -e
           # NOT 200 OK
@@ -52,9 +52,9 @@ jobs:
           echo "response=${response}"
           echo "message=${message}"
           if [[ "${message}" == "Branch not protected" ]] || [[ "${message}" == "Branch not found" ]]; then
-            echo "::notice::Milestone Branch Protection already deleted"
+            echo "::notice::Milestone Branch Protection \"${{ github.head_ref }}\" already deleted"
           else
-            echo "::error::Failed to delete branch protection: ${message}"
+            echo "::error::Failed to delete branch protection \"${{ github.head_ref }}\": ${message}"
             exit 1
           fi
         fi
@@ -68,7 +68,7 @@ jobs:
         then
           set -e
           # 200 OK
-          echo "::notice::Milestone Branch deleted"
+          echo "::notice::Milestone Branch \"${{ github.head_ref }}\" deleted"
         else
           set -e
           # NOT 200 OK
@@ -76,24 +76,39 @@ jobs:
           echo "response=${response}"
           echo "message=${message}"
           if [[ "${message}" == "Reference does not exist" ]]; then
-            echo "::notice::Milestone Branch already deleted"
+            echo "::notice::Milestone Branch \"${{ github.head_ref }}\" already deleted"
           else
-            echo "::error::Failed to delete milestone branch: ${message}"
+            echo "::error::Failed to delete milestone branch \"${{ github.head_ref }}\": ${message}"
             exit 1
           fi
         fi
 
 
   set-default-branch:
-    name: Set default branch back to master
+    # We need to first delete the milestone branch, otherwise it will popup in the next milestone
+    # branch list below
+    needs: delete-milestone-branch
+    name: Set default branch back to master or to next milestone branch
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.head_ref, 'develop-') }}
     steps:
-    - name: Set default branch back to master
+    - name: Set default branch back to master or to next milestone branch
       env:
         GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
       run: |
-        gh repo edit ${{ github.repository }} --default-branch master
+        next_milestone_branch=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/branches | \
+            jq '. | map(select(.name | test("develop-\\d{4}-\\d{2}-\\d{2}"))) | sort_by(.name) | .[0].name ' -r)
+        echo "next_milestone_branch=${next_milestone_branch}"
+        if [[ "${next_milestone_branch}" == "null" ]];
+        then
+          echo "::notice::Set default branch to \"master\""
+          gh repo edit ${{ github.repository }} --default-branch master
+        else
+          echo "::notice::Set default branch to \"${next_milestone_branch}\""
+          gh repo edit ${{ github.repository }} --default-branch "${next_milestone_branch}"
+        fi
 
 
   milestone-release:

--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -5,6 +5,8 @@ name: Milestone Release Reusable Workflow
 # tag is then <MILESTONE>-rc<X> where X is a milestone build number starting from 1.
 # The github release is then generated with release notes. The release notes are
 # generated from the PR titles.
+# Also remove milestone branch protection, delete the milestone branch and set the
+# default branch back to master.
 
 # Usage example
 # on:
@@ -17,11 +19,83 @@ name: Milestone Release Reusable Workflow
 # jobs:
 #   release:
 #     uses: geoadmin/.github/.github/workflows/milestone-release.yml@master
+#     secrets: inherit
 
 on:
   workflow_call:
+    secrets:
+      MY_SECRET:
+        required: true
 
 jobs:
+  delete-milestone-branch:
+    name: Delete Milestone Branch Protection
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.head_ref, 'develop-') }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Delete Milestone Branch Protection
+      env:
+        GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+        HUB_VERBOSE: 0
+      run: |
+        set +e
+        if response=$(hub api -X DELETE /repos/${{ github.repository }}/branches/${{ github.head_ref }}/protection);
+        then
+          set -e
+          # 200 OK
+          echo "::notice::Milestone Branch Protection deleted"
+        else
+          set -e
+          # NOT 200 OK
+          message=$(echo "${response}" | jq --raw-output '.message')
+          echo "response=${response}"
+          echo "message=${message}"
+          if [[ "${message}" == "Branch not protected" ]] || [[ "${message}" == "Branch not found" ]]; then
+            echo "::notice::Milestone Branch Protection already deleted"
+          else
+            echo "::error::Failed to delete branch protection: ${message}"
+            exit 1
+          fi
+        fi
+    - name: Delete Milestone Branch
+      env:
+        GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+        HUB_VERBOSE: 0
+      run: |
+        set +e
+        if response=$(hub api -X DELETE /repos/${{ github.repository }}/git/refs/heads/${{ github.head_ref }});
+        then
+          set -e
+          # 200 OK
+          echo "::notice::Milestone Branch deleted"
+        else
+          set -e
+          # NOT 200 OK
+          message=$(echo "${response}" | jq --raw-output '.message')
+          echo "response=${response}"
+          echo "message=${message}"
+          if [[ "${message}" == "Reference does not exist" ]]; then
+            echo "::notice::Milestone Branch already deleted"
+          else
+            echo "::error::Failed to delete milestone branch: ${message}"
+            exit 1
+          fi
+        fi
+
+
+  set-default-branch:
+    name: Set default branch back to master
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.head_ref, 'develop-') }}
+    steps:
+    - name: Set default branch back to master
+      env:
+        GITHUB_TOKEN: ${{ secrets.MY_SECRET }}
+      run: |
+        gh repo edit ${{ github.repository }} --default-branch master
+
+
   milestone-release:
     name: Release Milestone
     runs-on: ubuntu-latest
@@ -73,7 +147,8 @@ jobs:
       if: ${{ startsWith(github.head_ref, 'develop-') }}
       uses: "julb/action-manage-milestone@v1"
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         title: ${{ steps.get-milestone.outputs.milestone }}
         state: closed
+

--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -41,7 +41,6 @@ jobs:
           silent: false
 
   check-open-pr:
-    needs: add-milestone
     name: Check open PRs
     runs-on: ubuntu-latest
     if: ${{ github.base_ref == 'master' && startsWith(github.head_ref, 'develop-') }}

--- a/workflow-templates/create-milestone.yml
+++ b/workflow-templates/create-milestone.yml
@@ -6,3 +6,6 @@ on:
 jobs:
   milestone:
     uses: geoadmin/.github/.github/workflows/create-milestone.yml@master
+    secrets: inherit
+    with:
+      ci_status_check_name: ''

--- a/workflow-templates/milestone-version.yml
+++ b/workflow-templates/milestone-version.yml
@@ -10,3 +10,4 @@ on:
 jobs:
   release:
     uses: geoadmin/.github/.github/workflows/milestone-release.yml@master
+    secrets: inherit

--- a/workflow-templates/pr-auto-milestone.yml
+++ b/workflow-templates/pr-auto-milestone.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types:
       - opened
-      - edited
+      - reopened
       - synchronize
       - edited
 


### PR DESCRIPTION
Now when a milestone branch is created, a branch protection for this one is
automatically created. The protection requires at least one approval and
prevent merging directly to the branch. With the workflow input ci_status_check_name
we can configure a CI status check that must path in order to merge. It also
set the default branch to the created milestone branch.

When a milestone branch is merged and/or closed, the branch protection is
automatically removed and the branch is deleted. The default branch is set
back to master.

## TODO:
- [x] Adapt documentation, see https://github.com/geoadmin/doc-guidelines/pull/102
After merging this into `develop` we need to do the followings before going PROD (merge into `master`)
- [x] @boecklic create a new user with `admin` access to the milestone repositories (see list above).
- [x] @boecklic creates a token for this user with full repo access: 
![image](https://user-images.githubusercontent.com/67745584/177990253-90623f44-3e81-4be9-9662-ec3844dea52f.png)
- [x] @boecklic create an organization secrets called `REPO_ACCESS_TOKEN` with the user token created above.
- [x] @boecklic add the organization secrets to all milestone repo list below

Milestone repositories:
- geoadmin/mf-chsdi3
- geoadmin/service-wms-bod
- geoadmin/wms-bgdi
- geoadmin/wms-mapfile_include
- geoadmin/service-sphinxsearch


On all milestone repository we need to do the followings;
- [x] Check the `master` branch protection. This protection should be something like this 
![image](https://user-images.githubusercontent.com/67745584/177990654-f6652e7a-01d3-4da5-8554-df06e95d98ff.png)
It should also include administrator
- [ ] Update `.github/workflows/create-milestone.yml` on `master` only, as follow 
    ```yaml
    name: on-create
    
    on:
      create:
    
    jobs:
      milestone:
        uses: geoadmin/.github/.github/workflows/create-milestone.yml@master
        secrets: inherit
        with:
          ci_status_check_name: 'AWS CodeBuild eu-central-1 (CODEBUILD_PROJECT_NAME)'
    ```
    Replace `CODEBUILD_PROJECT_NAME` with the correct name.
- [ ] Update `.github/workflows/milestone-version.yml` with
    ```yaml
    name: on-pr-close
    
    on:
      pull_request:
        types:
          - closed
        branches:
          - master
    
    jobs:
      release:
        uses: geoadmin/.github/.github/workflows/milestone-release.yml@master
        secrets: inherit
    ```