### PR TITLE
BGDIINF_SB-2538: Fixed auto milestone

### DIFF
--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -33,12 +33,15 @@ jobs:
       milestone: ${{ steps.action_milestone.outputs.milestone }}
     steps:
       - id: action_milestone
-        uses: iyu/actions-milestone@v1.2.0
+        uses: iyu/actions-milestone@v1.3.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/pr-2-milestone-config.yml@master
           configuration-repo: geoadmin/.github
           silent: false
+          # Force the milestone overwrite and clear it if no match based on branch name is found
+          force: true
+          clear: true
 
   check-open-pr:
     name: Check open PRs

--- a/scripts/milestone-workflow-setup.sh
+++ b/scripts/milestone-workflow-setup.sh
@@ -37,7 +37,9 @@ case "$answer" in
 esac
 
 read -r -d '' MSG << EOM
-Added new Milestone Workflows
+Setup requirements for milestone branch protection and auto deletion
+
+See https://github.com/geoadmin/.github/pull/24
 EOM
 
 for repo in "${repository[@]}"
@@ -50,6 +52,17 @@ do
     cp ~/repositories/geoadmin.github/workflow-templates/milestone-version.yml .github/workflows/ || exit
     cp ~/repositories/geoadmin.github/workflow-templates/pr-auto-milestone.yml .github/workflows/ || exit
     cp ~/repositories/geoadmin.github/workflow-templates/create-milestone.yml .github/workflows/ || exit
+    if [[ "${repo}" == "service-sphinxsearch" ]]; then
+        sed -i "s/AWS CodeBuild eu-central-1 (CODEBUILD_PROJECT_NAME)//" .github/workflows/create-milestone.yml
+    else
+        CODEBUILD_PROJECT_NAME=${repo}
+        if [[ "${repo}" == "mf-chsdi3" ]]; then
+            CODEBUILD_PROJECT_NAME=${repo}-python3
+        elif [[ "${repo}" == "wms-bgdi" ]]; then
+            CODEBUILD_PROJECT_NAME=service-${repo}
+        fi
+        sed -i "s/CODEBUILD_PROJECT_NAME/${CODEBUILD_PROJECT_NAME}/" .github/workflows/create-milestone.yml
+    fi
     git add --all .github/workflows/ || exit
     git commit -m "$MSG" || exit
     git push -f origin HEAD || exit

--- a/workflow-templates/create-milestone.yml
+++ b/workflow-templates/create-milestone.yml
@@ -8,4 +8,4 @@ jobs:
     uses: geoadmin/.github/.github/workflows/create-milestone.yml@master
     secrets: inherit
     with:
-      ci_status_check_name: ''
+      ci_status_check_name: 'AWS CodeBuild eu-central-1 (CODEBUILD_PROJECT_NAME)'


### PR DESCRIPTION
When changing a PR base branch from milestone to master, then the milestone was
not cleared and it result to a wrong version ! This has been solved in the
iyu/actions-milestone action version v1.3.0 with the new feature `clear` and `force`