### PR TITLE
Fixed bug in PR auto title

### DIFF
--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -83,7 +83,7 @@ jobs:
 
           echo "Remove bump type from original title"
           pr_title="${{ steps.pr_infos.outputs.title }}"
-          pr_title="${pr_title//[#]$bump_type/}"
+          pr_title=$(echo ${pr_title} | sed "s/[ ]*-*[ ]*#${bump_type}//")
           echo "::set-output name=pr_title::${pr_title}"
 
       - name: Bump version (without tagging)


### PR DESCRIPTION
The when the title already contained ` - #minor` the new title resulted to
` -- #minor`, if the workflow was run one more time then it resulted to ` --- #minor`