### PR TITLE
Milestone workflow bug - update milestone branch with hotfix

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -64,9 +64,11 @@ jobs:
           required_status_checks=null
           if [[ -n "${{ inputs.ci_status_check_name }}" ]];
           then
+            # NOTE: we cannot set "strict" to true here otherwise we cannot update the milestone
+            # branch with the master hotfixes. (strict means "Require branches to be up to date before merging.")
             required_status_checks=$(cat <<-END
               {
-                "strict": true,
+                "strict": false,
                 "contexts": [
                   "${{ inputs.ci_status_check_name }}"
                 ]


### PR DESCRIPTION
If the milestone branch is protected in order to only allow merge of branch
that are up to date (aka "Require branches to be up to date before merging."),
then we cannot merge `master` into `develop-YYYY-MM-DD`.

The least worse solution for this problem is to allow merging non up to date
branch into the milestone branch. We can leverage the problem by setting the
general setting of the repo with "Always suggest updating pull request branches "
so when a regular feature branch PR to milestone is created the user will be
notify if its branch is not up to date, although he could still merge his PR
even his branch is not up to date.