### PR TITLE
Fixed the PR auto labeller bug

### DIFF
--- a/.github/release-drafter-labeler-config.yml
+++ b/.github/release-drafter-labeler-config.yml
@@ -1,27 +1,27 @@
 autolabeler:
   - label: 'new-release'
     branch:
-      - '/develop/'
-      - '/develop-.+/'
+      - '/^develop$/'
+      - '/^develop-/'
   - label: 'data-integration'
     branch:
-      - '/data[-_].+/'
+      - '/^data[-_]/'
   - label: 'bug'
     branch:
-      - '/bug[-_].+/'
-      - '/bugfix[-_].+/'
-      - '/fix[-_].+/'
+      - '/^bug[-_]/'
+      - '/^bugfix[-_]/'
+      - '/^fix[-_]/'
   - label: 'hotfix'
     branch:
-      - '/hotfix[-_].+'
-      - '/hot[-_].+'
+      - '/^hotfix[-_]/'
+      - '/^hot[-_]/'
   - label: 'feature'
     branch:
-      - '/feature[-_].+/'
-      - '/feat[-_].+/'
+      - '/^feature[-_]/'
+      - '/^feat[-_]/'
   - label: 'skip-release-note'
     branch:
       - '/update_README\.md/'
-      - '/norn[-_].+/'
-      - '/skiprn[-_].+/'
+      - '/\bnorn\b/'
+      - '/\bskip[-_]?rn\b/'
 template: '# Labeler'


### PR DESCRIPTION
If a PR had a head branch with `data-` or `data_` in its name (regardless of its
position in the name, the `data-integration` label was added.

Now the regex are correct and only check for the start of the string. With
the exception for the `skip-release-note` label that is added even if the
`norn`, `skip-rn`, `skiprn` text is found in the head branch.