### PR TITLE
Fixed milestone workflow

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -56,6 +56,9 @@ jobs:
     if: "${{ needs.get-milestone.outputs.milestone }}"
     runs-on: ubuntu-latest
     steps:
+      - name: Install hub tool
+        run: |
+          sudo apt-get update && sudo apt-get install -y hub
       - name: Create Milestone Branch Protection
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -33,6 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.head_ref, 'develop-') }}
     steps:
+    - name: Install hub tool
+      run: |
+        sudo apt-get update && sudo apt-get install -y hub
     - uses: actions/checkout@v2
     - name: Delete Milestone Branch Protection
       env:


### PR DESCRIPTION
Since a few week the milestone workflow don't work anymore because of this
announcement https://github.com/actions/runner-images/issues/8362

The `hub` tool is not anymore per default on the ubuntu-latest runner.