### PR TITLE
Try to fix dependabot on master set PR title issue

### DIFF
--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "New Release ${{ steps.get_tag.outputs.new_tag }} - #${{ steps.get_tag.outputs.part }}"
-          body: ${{ steps.pr_infos.outputs.body }}
+          body: "${{ steps.pr_infos.outputs.body }}"
 
       - name: Set `Hotfix` PR title if needed
         if: ${{ github.head_ref != 'develop' }}
@@ -111,7 +111,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "${{ steps.bump_type.outputs.pr_title }} - #${{ steps.get_tag.outputs.part }}"
-          body: ${{ steps.pr_infos.outputs.body }}
+          body: "${{ steps.pr_infos.outputs.body }}"
 
   pr-labeler:
     name: Set PR label


### PR DESCRIPTION
Dependabot uses quite complex PR body with HTML code, when creating a dependabot
PR to master the set PR title failed with

Error: HttpError: Resource not accessible by integration
Error: Resource not accessible by integration

Try to solve this by putting the body inside double quotes