### PR TITLE
Fix bash quoting

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -111,7 +111,7 @@ jobs:
           if [[ "${next_milestone_branch}" != "null" ]];
           then
             echo "::notice::Set default branch to \"${next_milestone_branch}\""
-            gh repo edit ${{ github.repository }} --default-branch ${next_milestone_branch}
+            gh repo edit ${{ github.repository }} --default-branch "${next_milestone_branch}"
           else
             echo "::warning::No milestone branch found !"
           fi

--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -158,7 +158,7 @@ jobs:
       shell: bash
       run: |
         tag=${{ steps.tagging.outputs.new_tag }}
-        milestone=${tag%%-rc*}
+        milestone="${tag%%-rc*}"
         echo "milestone=${milestone}" >> $GITHUB_OUTPUT
         echo "::notice::Milestone is ${milestone}"
     - name: Close the milestone if needed
@@ -169,6 +169,6 @@ jobs:
         milestone=$(gh api /repos/${{ github.repository }}/milestones | \
           jq -c '.[] | select(.title=="${{ steps.get-milestone.outputs.milestone }}").number')
         echo "::notice::Milestone found \"${milestone}\""
-        gh api /repos/${{ github.repository }}/milestones/${milestone} \
+        gh api "/repos/${{ github.repository }}/milestones/${milestone}" \
           --method "PATCH" \
           -f "state=closed"

--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           gh api "/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
             --method "PATCH" \
-            -f "title=New Release ${{ steps.get_tag.outputs.new_tag }}"
+            -f 'title=New Release ${{ steps.get_tag.outputs.new_tag }}'
 
   pr-labeler:
     name: Set PR label

--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -56,7 +56,7 @@ jobs:
           api_call="https://api.github.com/repos/${{ github.repository }}/pulls?state=open&base=${{ github.head_ref }}"
           echo "::notice::api call ${api_call}"
           counter=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: Bearer ${GITHUB_TOKEN}" "${api_call}" | jq '. | length')
-          if [[ ${counter:-0} > 0 ]]; then
+          if [[ "${counter:-0}" > 0 ]]; then
             echo "::error::${counter} open PR(s) on branch ${{ github.head_ref }}"
             exit 1
           else
@@ -89,7 +89,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
         run: |
-          gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER} \
+          gh api "/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
             --method "PATCH" \
             -f "title=New Release ${{ steps.get_tag.outputs.new_tag }}"
 

--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -45,7 +45,7 @@ jobs:
       # overwrite any bump type by any previous commit
       - name: Do the merge but don't push it
         run: |
-          cd ${GITHUB_WORKSPACE}
+          cd "${GITHUB_WORKSPACE}"
           git config user.email "github@swisstopo.ch"
           git config user.name "Github PR Auto Title Workflow"
           git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}
@@ -68,7 +68,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}"
           echo "PR_BODY"
           echo "----------------"
-          echo ${PR_BODY}
+          echo "${PR_BODY}"
           echo "----------------"
 
           case "${PR_BODY}" in
@@ -84,8 +84,8 @@ jobs:
           esac
 
           echo "Remove bump type from original title"
-          pr_title="${{ github.event.pull_request.title }}"
-          pr_title=$(echo ${pr_title} | sed "s/[ ]*-*[ ]*#${bump_type}//")
+          pr_title="${PR_TITLE}"
+          pr_title=$(echo "${pr_title}" | sed "s/[ ]*-*[ ]*#${bump_type}//")
 
           echo "pr_title=${pr_title}" >> $GITHUB_OUTPUT
           echo "Original title set to '${pr_title}'"
@@ -111,7 +111,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
         run: |
-          gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER} \
+          gh api "§/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
             --method "PATCH" \
             -f "title=New Release ${{ steps.get_tag.outputs.new_tag }} - #${{ steps.get_tag.outputs.part }}"
 
@@ -121,7 +121,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
         run: |
-          gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER} \
+          gh api "/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
             --method "PATCH" \
             -f "title=${{ steps.bump_type.outputs.pr_title }} - #${{ steps.get_tag.outputs.part }}"
 

--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -85,7 +85,9 @@ jobs:
 
           echo "Remove bump type from original title"
           pr_title="${PR_TITLE}"
-          pr_title=$(echo "${pr_title}" | sed "s/[ ]*-*[ ]*#${bump_type}//")
+          # We use sed at the end to properly escape the single quotes characters
+          # to avoid any issues later one when using the title in bash command if the title contains quotes
+          pr_title=$(echo "${pr_title}" | sed "s/[ ]*-*[ ]*#${bump_type}//" | sed "s/'/'\\\\''/g")
 
           echo "pr_title=${pr_title}" >> $GITHUB_OUTPUT
           echo "Original title set to '${pr_title}'"
@@ -111,9 +113,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
         run: |
-          gh api "§/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
+          gh api "/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
             --method "PATCH" \
-            -f "title=New Release ${{ steps.get_tag.outputs.new_tag }} - #${{ steps.get_tag.outputs.part }}"
+            -f 'title=New Release ${{ steps.get_tag.outputs.new_tag }} - #${{ steps.get_tag.outputs.part }}'
 
       - name: Set `Hotfix` PR title if needed
         if: ${{ github.head_ref != 'develop' }}
@@ -123,7 +125,7 @@ jobs:
         run: |
           gh api "/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
             --method "PATCH" \
-            -f "title=${{ steps.bump_type.outputs.pr_title }} - #${{ steps.get_tag.outputs.part }}"
+            -f 'title=${{ steps.bump_type.outputs.pr_title }} - #${{ steps.get_tag.outputs.part }}'
 
   pr-labeler:
     name: Set PR label


### PR DESCRIPTION
The "Get Default Bump Type from PR and get PR Title" action did not worked on the following PR https://github.com/geoadmin/web-mapviewer/pull/985 due to bash word splitting.

In Bash to prevent globbing and word splitting you need to double quote the variables. So I corrected all bash variable to avoid such issues in future.