### PR TITLE
PB-1289: Update action-milestone-tag

### DIFF
--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -131,7 +131,7 @@ jobs:
 
     - name: Bump Milestone Tag
       id: tagging
-      uses: geoadmin/action-milestone-tag@v1.4.0
+      uses: geoadmin/action-milestone-tag@v1.5.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         custom_tag: '${MILESTONE}-rc${TAG_NUMBER}'

--- a/.github/workflows/pr-auto-milestone.yml
+++ b/.github/workflows/pr-auto-milestone.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Bump version (without tagging)
         id: get_tag
-        uses: geoadmin/action-milestone-tag@v1.4.0
+        uses: geoadmin/action-milestone-tag@v1.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: '${MILESTONE}-rc${TAG_NUMBER}'


### PR DESCRIPTION
The new version utilise the latest actions/upload-artifact
I tested it with https://github.com/geoadmin/test-milestone-workflow/pull/198