### PR TITLE
Do not allow to merge milestone repo PR when the `Add PR to Milestone` action is not runned

### DIFF
--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -72,7 +72,8 @@ jobs:
               {
                 "strict": false,
                 "contexts": [
-                  "${{ inputs.ci_status_check_name }}"
+                  "${{ inputs.ci_status_check_name }}",
+                  "pr-edit / Add PR to Milestone"
                 ]
               }
           END)


### PR DESCRIPTION
This action is required in order to properly tagged the repo when merging the PR.i